### PR TITLE
A successful message was displayed even if InjectDll failed

### DIFF
--- a/src/inject.cc
+++ b/src/inject.cc
@@ -8,6 +8,7 @@
 #include <tlhelp32.h>
 #include <vector>
 
+
 HANDLE OpenRemoteProcess(const uint32_t ProcessId) {
   const uint32_t ProcessRights =
       PROCESS_CREATE_THREAD | PROCESS_QUERY_INFORMATION | PROCESS_VM_OPERATION |
@@ -22,77 +23,86 @@ HANDLE OpenRemoteProcess(const uint32_t ProcessId) {
   return Process;
 }
 
-PVOID AllocateMemInRemoteProcess(HANDLE RemoteProcess,
+PVOID AllocateMemInRemoteProcess(HANDLE hRemoteProcess,
                                  const std::filesystem::path &Path) {
+  const std::string DllPath = Path.string();
+  const size_t DllPathLen = DllPath.size() + 1;
+  SIZE_T BytesWritten;
 
-  const PVOID RemoteDllPath = VirtualAllocEx(RemoteProcess, nullptr, 0x1000, MEM_COMMIT | MEM_RESERVE,
+  const PVOID RemoteDllPath = VirtualAllocEx(hRemoteProcess, nullptr, 0x1000, MEM_COMMIT | MEM_RESERVE,
                      PAGE_READWRITE);
 
   if (RemoteDllPath == nullptr) {
     printf("VirtualAllocEx failed.\n");
-    return nullptr;
+    goto Error;
   }
 
-  const std::string DllPath = Path.string();
-  const size_t DllPathLen = DllPath.size() + 1;
-  SIZE_T BytesWritten;
-  if (!WriteProcessMemory(RemoteProcess, RemoteDllPath, DllPath.c_str(),
+  if (!WriteProcessMemory(hRemoteProcess, RemoteDllPath, DllPath.c_str(),
                           DllPathLen,
                           &BytesWritten)) {
-    VirtualFreeEx(RemoteProcess, RemoteDllPath, 0, MEM_RELEASE);
+    VirtualFreeEx(hRemoteProcess, RemoteDllPath, 0, MEM_RELEASE);
     printf("WriteProcessMemory failed.\n");
-    return nullptr;
+    goto Error;
   }
 
   return RemoteDllPath;
+
+Error:
+  CloseHandle(hRemoteProcess);
+  return nullptr;
 }
 
-HANDLE CreateThreadInRemoteProcess(HANDLE RemoteProcess, PVOID RemoteDllPath) {
+HANDLE CreateThreadInRemoteProcess(HANDLE hRemoteProcess, PVOID RemoteDllPath) {
+  PVOID LoadLibraryA;
+  HANDLE Thread;
+  DWORD Tid;
+
   const HMODULE Kernelbase = GetModuleHandleA("kernelbase");
   if (Kernelbase == nullptr) {
     printf("GetModuleHandleA failed.\n");
-    return INVALID_HANDLE_VALUE;
+    goto Error;
   }
 
-  const PVOID LoadLibraryA = PVOID(GetProcAddress(Kernelbase, "LoadLibraryA"));
+  LoadLibraryA = PVOID(GetProcAddress(Kernelbase, "LoadLibraryA"));
   if (LoadLibraryA == nullptr) {
     printf("GetProcAddress failed.\n");
-    return INVALID_HANDLE_VALUE;
+    goto Error;
   }
 
-  DWORD Tid = 0;
-  const HANDLE Thread = CreateRemoteThread(RemoteProcess, nullptr, 0,
+  Thread = CreateRemoteThread(hRemoteProcess, nullptr, 0,
                                            LPTHREAD_START_ROUTINE(LoadLibraryA),
                                            RemoteDllPath, 0, &Tid);
 
-  if (Thread == nullptr) {
+  if (Thread == NULL) {
     printf("CreateRemoteThread failed.\n");
-    return INVALID_HANDLE_VALUE;
+    goto Error;
   }
 
   printf("Thread with ID %d has been created.\n", Tid);
 
   return Thread;
+
+Error:
+  VirtualFreeEx(hRemoteProcess, RemoteDllPath, 0, MEM_RELEASE);
+  CloseHandle(hRemoteProcess);
+  return INVALID_HANDLE_VALUE;
 }
 
-bool InjectDll(const uint32_t ProcessId, const std::filesystem::path &Path) {
-  bool InjectResult = false;
+DWORD InjectDll(const uint32_t ProcessId, const std::filesystem::path &Path) {
+  DWORD InjectResult = EXIT_FAILURE;
 
-  HANDLE RemoteProcess = OpenRemoteProcess(ProcessId);
-  if (RemoteProcess == INVALID_HANDLE_VALUE) {
+  HANDLE hRemoteProcess = OpenRemoteProcess(ProcessId);
+  if (hRemoteProcess == INVALID_HANDLE_VALUE) {
     return InjectResult;
   }
   
-  const PVOID RemoteDllPath = AllocateMemInRemoteProcess(RemoteProcess, Path);
+  const PVOID RemoteDllPath = AllocateMemInRemoteProcess(hRemoteProcess, Path);
   if (RemoteDllPath == nullptr) {
-    CloseHandle(RemoteProcess);
     return InjectResult;
   }
 
-  const HANDLE Thread = CreateThreadInRemoteProcess(RemoteProcess, RemoteDllPath);
+  const HANDLE Thread = CreateThreadInRemoteProcess(hRemoteProcess, RemoteDllPath);
   if (Thread == INVALID_HANDLE_VALUE) {
-    VirtualFreeEx(RemoteProcess, RemoteDllPath, 0, MEM_RELEASE);
-    CloseHandle(RemoteProcess);
     return InjectResult;
   }
 
@@ -100,16 +110,16 @@ bool InjectDll(const uint32_t ProcessId, const std::filesystem::path &Path) {
 
   DWORD ExitCode = 0;
   GetExitCodeThread(Thread, &ExitCode);
-  InjectResult = true;
+  InjectResult = EXIT_SUCCESS;
 
   if (ExitCode == 0) {
     printf("/!\\ The thread failed to load the dll. ");
-    InjectResult = false;
+    InjectResult = EXIT_FAILURE;
   }
 
   CloseHandle(Thread);
-  VirtualFreeEx(RemoteProcess, RemoteDllPath, 0, MEM_RELEASE);
-  CloseHandle(RemoteProcess);
+  VirtualFreeEx(hRemoteProcess, RemoteDllPath, 0, MEM_RELEASE);
+  CloseHandle(hRemoteProcess);
   return InjectResult;
 }
 
@@ -174,7 +184,7 @@ int main(int Argc, const char *Argv[]) {
   for (const std::filesystem::path &Dll : Dlls) {
     const std::filesystem::path DllAbsolute = std::filesystem::absolute(Dll);
     const DWORD Succeed = InjectDll(ProcessId, DllAbsolute);
-    if (!Succeed) {
+    if (Succeed == EXIT_FAILURE) {
       printf("Error while injecting %ls in %d\n", DllAbsolute.c_str(),
              ProcessId);
       return EXIT_FAILURE;

--- a/src/inject.cc
+++ b/src/inject.cc
@@ -8,7 +8,8 @@
 #include <tlhelp32.h>
 #include <vector>
 
-DWORD InjectDll(const uint32_t ProcessId, const std::filesystem::path &Path) {
+
+HANDLE OpenRemoteProcess(const uint32_t ProcessId) {
   const uint32_t ProcessRights =
       PROCESS_CREATE_THREAD | PROCESS_QUERY_INFORMATION | PROCESS_VM_OPERATION |
       PROCESS_VM_WRITE | PROCESS_VM_READ;
@@ -16,65 +17,110 @@ DWORD InjectDll(const uint32_t ProcessId, const std::filesystem::path &Path) {
 
   if (Process == nullptr) {
     printf("Failed to open the remote process.\n");
-    return EXIT_FAILURE;
+    return INVALID_HANDLE_VALUE;
   }
 
-  const PVOID RemoteDllPath = VirtualAllocEx(
-      Process, nullptr, 0x1000, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+  return Process;
+}
 
-  if (RemoteDllPath == nullptr) {
-    printf("VirtualAllocEx failed.\n");
-    return EXIT_FAILURE;
-  }
-
+PVOID AllocateMemInRemoteProcess(HANDLE hRemoteProcess,
+                                 const std::filesystem::path &Path) {
   const std::string DllPath = Path.string();
   const size_t DllPathLen = DllPath.size() + 1;
   SIZE_T BytesWritten;
-  if (!WriteProcessMemory(Process, RemoteDllPath, DllPath.c_str(), DllPathLen,
-                          &BytesWritten)) {
-    printf("WriteProcessMemory failed.\n");
-    return EXIT_FAILURE;
+
+  const PVOID RemoteDllPath = VirtualAllocEx(hRemoteProcess, nullptr, 0x1000, MEM_COMMIT | MEM_RESERVE,
+                     PAGE_READWRITE);
+
+  if (RemoteDllPath == nullptr) {
+    printf("VirtualAllocEx failed.\n");
+    goto Error;
   }
+
+  if (!WriteProcessMemory(hRemoteProcess, RemoteDllPath, DllPath.c_str(),
+                          DllPathLen,
+                          &BytesWritten)) {
+    VirtualFreeEx(hRemoteProcess, RemoteDllPath, 0, MEM_RELEASE);
+    printf("WriteProcessMemory failed.\n");
+    goto Error;
+  }
+
+  return RemoteDllPath;
+
+Error:
+  CloseHandle(hRemoteProcess);
+  return nullptr;
+}
+
+HANDLE CreateThreadInRemoteProcess(HANDLE hRemoteProcess, PVOID RemoteDllPath) {
+  PVOID LoadLibraryA;
+  HANDLE Thread;
+  DWORD Tid;
 
   const HMODULE Kernelbase = GetModuleHandleA("kernelbase");
   if (Kernelbase == nullptr) {
     printf("GetModuleHandleA failed.\n");
-    return EXIT_FAILURE;
+    goto Error;
   }
 
-  const PVOID LoadLibraryA = PVOID(GetProcAddress(Kernelbase, "LoadLibraryA"));
+  LoadLibraryA = PVOID(GetProcAddress(Kernelbase, "LoadLibraryA"));
   if (LoadLibraryA == nullptr) {
     printf("GetProcAddress failed.\n");
-    return EXIT_FAILURE;
+    goto Error;
   }
 
-  DWORD Tid;
-  const HANDLE Thread = CreateRemoteThread(Process, nullptr, 0,
+  Thread = CreateRemoteThread(hRemoteProcess, nullptr, 0,
                                            LPTHREAD_START_ROUTINE(LoadLibraryA),
                                            RemoteDllPath, 0, &Tid);
 
   if (Thread == NULL) {
     printf("CreateRemoteThread failed.\n");
-    return EXIT_FAILURE;
+    goto Error;
   }
+
   printf("Thread with ID %d has been created.\n", Tid);
+
+  return Thread;
+
+Error:
+  VirtualFreeEx(hRemoteProcess, RemoteDllPath, 0, MEM_RELEASE);
+  CloseHandle(hRemoteProcess);
+  return INVALID_HANDLE_VALUE;
+}
+
+DWORD InjectDll(const uint32_t ProcessId, const std::filesystem::path &Path) {
+  DWORD InjectResult = EXIT_FAILURE;
+
+  HANDLE hRemoteProcess = OpenRemoteProcess(ProcessId);
+  if (hRemoteProcess == INVALID_HANDLE_VALUE) {
+    return InjectResult;
+  }
+  
+  const PVOID RemoteDllPath = AllocateMemInRemoteProcess(hRemoteProcess, Path);
+  if (RemoteDllPath == nullptr) {
+    return InjectResult;
+  }
+
+  const HANDLE Thread = CreateThreadInRemoteProcess(hRemoteProcess, RemoteDllPath);
+  if (Thread == INVALID_HANDLE_VALUE) {
+    return InjectResult;
+  }
 
   WaitForSingleObject(Thread, INFINITE);
 
   DWORD ExitCode = 0;
   GetExitCodeThread(Thread, &ExitCode);
+  InjectResult = EXIT_SUCCESS;
 
   if (ExitCode == 0) {
-    printf("/!\\ The thread failed to load the dll.\n");
-    return EXIT_FAILURE;
+    printf("/!\\ The thread failed to load the dll. ");
+    InjectResult = EXIT_FAILURE;
   }
 
-  printf("The remote thread exited with error code: %#x.\n", ExitCode);
-
   CloseHandle(Thread);
-  VirtualFreeEx(Process, RemoteDllPath, 0, MEM_RELEASE);
-  CloseHandle(Process);
-  return EXIT_SUCCESS;
+  VirtualFreeEx(hRemoteProcess, RemoteDllPath, 0, MEM_RELEASE);
+  CloseHandle(hRemoteProcess);
+  return InjectResult;
 }
 
 bool Pid2Name(const char *ProcessName, uint32_t &Pid) {

--- a/src/inject.cc
+++ b/src/inject.cc
@@ -8,7 +8,6 @@
 #include <tlhelp32.h>
 #include <vector>
 
-
 HANDLE OpenRemoteProcess(const uint32_t ProcessId) {
   const uint32_t ProcessRights =
       PROCESS_CREATE_THREAD | PROCESS_QUERY_INFORMATION | PROCESS_VM_OPERATION |
@@ -23,86 +22,77 @@ HANDLE OpenRemoteProcess(const uint32_t ProcessId) {
   return Process;
 }
 
-PVOID AllocateMemInRemoteProcess(HANDLE hRemoteProcess,
+PVOID AllocateMemInRemoteProcess(HANDLE RemoteProcess,
                                  const std::filesystem::path &Path) {
-  const std::string DllPath = Path.string();
-  const size_t DllPathLen = DllPath.size() + 1;
-  SIZE_T BytesWritten;
 
-  const PVOID RemoteDllPath = VirtualAllocEx(hRemoteProcess, nullptr, 0x1000, MEM_COMMIT | MEM_RESERVE,
+  const PVOID RemoteDllPath = VirtualAllocEx(RemoteProcess, nullptr, 0x1000, MEM_COMMIT | MEM_RESERVE,
                      PAGE_READWRITE);
 
   if (RemoteDllPath == nullptr) {
     printf("VirtualAllocEx failed.\n");
-    goto Error;
+    return nullptr;
   }
 
-  if (!WriteProcessMemory(hRemoteProcess, RemoteDllPath, DllPath.c_str(),
+  const std::string DllPath = Path.string();
+  const size_t DllPathLen = DllPath.size() + 1;
+  SIZE_T BytesWritten;
+  if (!WriteProcessMemory(RemoteProcess, RemoteDllPath, DllPath.c_str(),
                           DllPathLen,
                           &BytesWritten)) {
-    VirtualFreeEx(hRemoteProcess, RemoteDllPath, 0, MEM_RELEASE);
+    VirtualFreeEx(RemoteProcess, RemoteDllPath, 0, MEM_RELEASE);
     printf("WriteProcessMemory failed.\n");
-    goto Error;
+    return nullptr;
   }
 
   return RemoteDllPath;
-
-Error:
-  CloseHandle(hRemoteProcess);
-  return nullptr;
 }
 
-HANDLE CreateThreadInRemoteProcess(HANDLE hRemoteProcess, PVOID RemoteDllPath) {
-  PVOID LoadLibraryA;
-  HANDLE Thread;
-  DWORD Tid;
-
+HANDLE CreateThreadInRemoteProcess(HANDLE RemoteProcess, PVOID RemoteDllPath) {
   const HMODULE Kernelbase = GetModuleHandleA("kernelbase");
   if (Kernelbase == nullptr) {
     printf("GetModuleHandleA failed.\n");
-    goto Error;
+    return INVALID_HANDLE_VALUE;
   }
 
-  LoadLibraryA = PVOID(GetProcAddress(Kernelbase, "LoadLibraryA"));
+  const PVOID LoadLibraryA = PVOID(GetProcAddress(Kernelbase, "LoadLibraryA"));
   if (LoadLibraryA == nullptr) {
     printf("GetProcAddress failed.\n");
-    goto Error;
+    return INVALID_HANDLE_VALUE;
   }
 
-  Thread = CreateRemoteThread(hRemoteProcess, nullptr, 0,
+  DWORD Tid = 0;
+  const HANDLE Thread = CreateRemoteThread(RemoteProcess, nullptr, 0,
                                            LPTHREAD_START_ROUTINE(LoadLibraryA),
                                            RemoteDllPath, 0, &Tid);
 
-  if (Thread == NULL) {
+  if (Thread == nullptr) {
     printf("CreateRemoteThread failed.\n");
-    goto Error;
+    return INVALID_HANDLE_VALUE;
   }
 
   printf("Thread with ID %d has been created.\n", Tid);
 
   return Thread;
-
-Error:
-  VirtualFreeEx(hRemoteProcess, RemoteDllPath, 0, MEM_RELEASE);
-  CloseHandle(hRemoteProcess);
-  return INVALID_HANDLE_VALUE;
 }
 
-DWORD InjectDll(const uint32_t ProcessId, const std::filesystem::path &Path) {
-  DWORD InjectResult = EXIT_FAILURE;
+bool InjectDll(const uint32_t ProcessId, const std::filesystem::path &Path) {
+  bool InjectResult = false;
 
-  HANDLE hRemoteProcess = OpenRemoteProcess(ProcessId);
-  if (hRemoteProcess == INVALID_HANDLE_VALUE) {
+  HANDLE RemoteProcess = OpenRemoteProcess(ProcessId);
+  if (RemoteProcess == INVALID_HANDLE_VALUE) {
     return InjectResult;
   }
   
-  const PVOID RemoteDllPath = AllocateMemInRemoteProcess(hRemoteProcess, Path);
+  const PVOID RemoteDllPath = AllocateMemInRemoteProcess(RemoteProcess, Path);
   if (RemoteDllPath == nullptr) {
+    CloseHandle(RemoteProcess);
     return InjectResult;
   }
 
-  const HANDLE Thread = CreateThreadInRemoteProcess(hRemoteProcess, RemoteDllPath);
+  const HANDLE Thread = CreateThreadInRemoteProcess(RemoteProcess, RemoteDllPath);
   if (Thread == INVALID_HANDLE_VALUE) {
+    VirtualFreeEx(RemoteProcess, RemoteDllPath, 0, MEM_RELEASE);
+    CloseHandle(RemoteProcess);
     return InjectResult;
   }
 
@@ -110,16 +100,16 @@ DWORD InjectDll(const uint32_t ProcessId, const std::filesystem::path &Path) {
 
   DWORD ExitCode = 0;
   GetExitCodeThread(Thread, &ExitCode);
-  InjectResult = EXIT_SUCCESS;
+  InjectResult = true;
 
   if (ExitCode == 0) {
     printf("/!\\ The thread failed to load the dll. ");
-    InjectResult = EXIT_FAILURE;
+    InjectResult = false;
   }
 
   CloseHandle(Thread);
-  VirtualFreeEx(hRemoteProcess, RemoteDllPath, 0, MEM_RELEASE);
-  CloseHandle(hRemoteProcess);
+  VirtualFreeEx(RemoteProcess, RemoteDllPath, 0, MEM_RELEASE);
+  CloseHandle(RemoteProcess);
   return InjectResult;
 }
 

--- a/src/inject.cc
+++ b/src/inject.cc
@@ -174,7 +174,7 @@ int main(int Argc, const char *Argv[]) {
   for (const std::filesystem::path &Dll : Dlls) {
     const std::filesystem::path DllAbsolute = std::filesystem::absolute(Dll);
     const DWORD Succeed = InjectDll(ProcessId, DllAbsolute);
-    if (Succeed == EXIT_FAILURE) {
+    if (!Succeed) {
       printf("Error while injecting %ls in %d\n", DllAbsolute.c_str(),
              ProcessId);
       return EXIT_FAILURE;


### PR DESCRIPTION
I tried to use `inject`  against a protected process which wouldn't allow to be opened. Despite the `OpenProcess` API was failing, the tool was displaying a successful message on the command prompt.
On failing, `InjectDll` was rcorrectly eturning `EXIT_FAILURE`,  but the subsequent check [here](https://github.com/0vercl0k/inject/blob/fbecc98ae7fe2cd2a7a125d9a72193810e4a1ce4/src/inject.cc#L136) wasn't correct.

This PR fixes this issue.